### PR TITLE
useframev2

### DIFF
--- a/src/SimpleParallelAnalyzer.cpp
+++ b/src/SimpleParallelAnalyzer.cpp
@@ -6,6 +6,7 @@ SimpleParallelAnalyzer::SimpleParallelAnalyzer()
     : Analyzer2(), mSettings( new SimpleParallelAnalyzerSettings() ), mSimulationInitilized( false )
 {
     SetAnalyzerSettings( mSettings.get() );
+    UseFrameV2();
 }
 
 SimpleParallelAnalyzer::~SimpleParallelAnalyzer()


### PR DESCRIPTION
This won't build until the new UseFrameV2(); Function has become an official part of the SDK. In the meantime, do not use `UseFrameV2();`, as it will fail to build.