### PR TITLE
Add chip select support

### DIFF
--- a/src/SimpleParallelAnalyzer.cpp
+++ b/src/SimpleParallelAnalyzer.cpp
@@ -35,6 +35,8 @@ void SimpleParallelAnalyzer::WorkerThread()
 
 
     mClock = GetAnalyzerChannelData( mSettings->mClockChannel );
+    mChipSelect = GetAnalyzerChannelData( mSettings->mChipSelectChannel );
+    
     mData.clear();
     mDataMasks.clear();
     mDataChannels.clear();
@@ -50,141 +52,81 @@ void SimpleParallelAnalyzer::WorkerThread()
         }
     }
 
+    // Move the clock to the falling edge of CS.
+    if ( mChipSelect->GetBitState() == BIT_HIGH) {
+        mChipSelect->AdvanceToNextEdge(); // Falling
+        mClock->AdvanceToAbsPosition(mChipSelect->GetSampleNumber());
+    }
 
     U32 num_data_lines = mData.size();
-
-    if( mSettings->mClockEdge == ParallelAnalyzerClockEdge::NegEdge )
-    {
-        if( mClock->GetBitState() == BIT_LOW )
-            mClock->AdvanceToNextEdge();
-    }
-    else if( mSettings->mClockEdge == ParallelAnalyzerClockEdge::PosEdge )
-    {
-        if( mClock->GetBitState() == BIT_HIGH )
-            mClock->AdvanceToNextEdge();
-    }
-    else if( mSettings->mClockEdge == ParallelAnalyzerClockEdge::DualEdge )
-    {
-        // handling both edges is different enough to warrant a separate implementation.
-        DecodeBothEdges();
-        return;
-    }
-
-    mClock->AdvanceToNextEdge(); // this is the data-valid edge
-
-    Frame last_frame;
-    bool is_first_frame = true;
     for( ;; )
     {
-        // We always start this loop on an active edge.
-
-        U64 sample = mClock->GetSampleNumber();
-        mResults->AddMarker( sample, clock_arrow, mSettings->mClockChannel );
-
-        U16 result = GetWordAtLocation( sample );
-
-        FrameV2 frame_v2;
-        frame_v2.AddInteger( "data", result );
-
-        Frame frame;
-        frame.mData1 = result;
-        frame.mFlags = 0;
-        frame.mStartingSampleInclusive = sample;
-
-        // The code in these if/else blocks could be replaced with 2 `AdvanceToNextEdge` calls, but if no more transitions are encountered,
-        // the current state will never be output as a frame. These blocks will detect that case in the available data, and output a frame
-        // immediately, and then another one once the next active edge sample is known.
-        if( !mClock->DoMoreTransitionsExistInCurrentData() )
-        {
-            // There are no transitions available in the current data. Estimate what the frame size might be as 10 if we haven't seen any
-            // frames yet, otherwise use 10% of the last frame size.
-            U64 estimated_frame_size = 10;
-            if( !is_first_frame )
-            {
-                U64 last_frame_sample_count = last_frame.mEndingSampleInclusive - last_frame.mStartingSampleInclusive + 1;
-                estimated_frame_size = last_frame_sample_count * 0.1;
-                if( estimated_frame_size < 3 )
-                {
-                    estimated_frame_size = 3;
-                }
-            }
-
-            // Make sure we haven't gone past the end of the _real_ frame. WouldAdvancingCauseTransition can block, in which case more
-            // transitions might show up.
-            if( mClock->WouldAdvancingCauseTransition( estimated_frame_size ) )
-            {
-                // Move to inactive edge
-                mClock->AdvanceToNextEdge();
-                if( mClock->DoMoreTransitionsExistInCurrentData() )
-                {
-                    // Move to active edge
-                    mClock->AdvanceToNextEdge();
-
-                    frame.mEndingSampleInclusive = mClock->GetSampleNumber() - 1;
-                    mResults->AddFrame( frame );
-                    mResults->AddFrameV2( frame_v2, "data", frame.mStartingSampleInclusive, frame.mEndingSampleInclusive );
-                    mResults->CommitResults();
-                }
-                else
-                {
-                    frame.mEndingSampleInclusive = mClock->GetSampleNumber() - 1;
-                    mResults->AddFrame( frame );
-                    mResults->AddFrameV2( frame_v2, "data", frame.mStartingSampleInclusive, frame.mEndingSampleInclusive );
-                    mResults->CommitResults();
-
-                    // Move to active edge
-                    mClock->AdvanceToNextEdge();
-                }
-            }
-            else
-            {
-                frame.mEndingSampleInclusive = sample + estimated_frame_size - 1;
-                if( frame.mEndingSampleInclusive <= frame.mStartingSampleInclusive )
-                {
-                    frame.mEndingSampleInclusive = frame.mStartingSampleInclusive + 1;
-                }
-                mResults->AddFrame( frame );
-                mResults->AddFrameV2( frame_v2, "data", frame.mStartingSampleInclusive, frame.mEndingSampleInclusive );
-                mResults->CommitResults();
-
-                // Move to inactive edge, and then the active edge
-                mClock->AdvanceToNextEdge();
-                mClock->AdvanceToNextEdge();
-            }
-        }
-        else
-        {
-            // Move to inactive edge
+        S64 index = 0;
+        bool end_with_cs = false;
+        // Skip to the next inactive edge.
+        if( (mSettings->mClockEdge == ParallelAnalyzerClockEdge::NegEdge && mClock->GetBitState() == BIT_LOW) ||
+            (mSettings->mClockEdge == ParallelAnalyzerClockEdge::PosEdge && mClock->GetBitState() == BIT_HIGH) ) {
             mClock->AdvanceToNextEdge();
-
-            if( mClock->DoMoreTransitionsExistInCurrentData() )
-            {
-                // Move to active edge
-                mClock->AdvanceToNextEdge();
-
-                frame.mEndingSampleInclusive = mClock->GetSampleNumber() - 1;
-                mResults->AddFrame( frame );
-                mResults->AddFrameV2( frame_v2, "data", frame.mStartingSampleInclusive, frame.mEndingSampleInclusive );
-                mResults->CommitResults();
-            }
-            else
-            {
-                frame.mEndingSampleInclusive = mClock->GetSampleNumber() - 1;
-                mResults->AddFrame( frame );
-                mResults->AddFrameV2( frame_v2, "data", frame.mStartingSampleInclusive, frame.mEndingSampleInclusive );
-                mResults->CommitResults();
-
-                // Move to active edge
-                mClock->AdvanceToNextEdge();
-            }
+            end_with_cs = true;
         }
 
-        // Note: mClock should always be at an active edge at this point, and `frame` should have been added.
+        while (!mChipSelect->WouldAdvancingToAbsPositionCauseTransition(mClock->GetSampleOfNextEdge())) {
+            auto frame_start = mClock->GetSampleNumber();
+            mClock->AdvanceToNextEdge(); // Active
+            U64 sample = mClock->GetSampleNumber();
 
-        is_first_frame = false;
-        last_frame = frame;
+            mResults->AddMarker( sample, clock_arrow, mSettings->mClockChannel );
 
-        ReportProgress( frame.mEndingSampleInclusive );
+            U16 result = GetWordAtLocation( sample );
+
+            FrameV2 frame_v2;
+            frame_v2.AddInteger( "data", result );
+            frame_v2.AddInteger( "index", index );
+            index += 1;
+
+            Frame frame;
+            frame.mData1 = result;
+            frame.mFlags = 0;
+            frame.mStartingSampleInclusive = frame_start;
+
+            // Move to next inactive edge or the end of cs.
+            if (end_with_cs) {
+                while (!mClock->DoMoreTransitionsExistInCurrentData() &&
+                       !mChipSelect->DoMoreTransitionsExistInCurrentData()) {
+                    // Wait for clock or chip select transitions.
+                }
+                // Only get the next edge of the signal we have a transition for. Once we do, make
+                // sure the other signal doesn't transition earlier. Move mClock to the earlier of
+                // the transitions to end the frame.
+                if (mClock->DoMoreTransitionsExistInCurrentData()) {
+                    if (mChipSelect->WouldAdvancingToAbsPositionCauseTransition(mClock->GetSampleOfNextEdge())) {
+                        mClock->AdvanceToAbsPosition(mChipSelect->GetSampleOfNextEdge());
+                    } else {
+                        mClock->AdvanceToNextEdge();
+                    }
+                } else {
+                    if (mClock->WouldAdvancingToAbsPositionCauseTransition(mChipSelect->GetSampleOfNextEdge())) {
+                        mClock->AdvanceToNextEdge();
+                    } else {
+                        mClock->AdvanceToAbsPosition(mChipSelect->GetSampleOfNextEdge());
+                    }
+                }
+            } else {
+                mClock->AdvanceToNextEdge();
+            }
+
+            frame.mEndingSampleInclusive = mClock->GetSampleNumber() - 1;
+            frame_start = mClock->GetSampleNumber();
+            mResults->AddFrame( frame );
+            mResults->AddFrameV2( frame_v2, "data", frame.mStartingSampleInclusive, frame.mEndingSampleInclusive );
+            mResults->CommitResults();
+            ReportProgress( frame.mEndingSampleInclusive );
+        }
+        mChipSelect->AdvanceToNextEdge(); // Rising
+        ReportProgress( mChipSelect->GetSampleNumber() );
+        mChipSelect->AdvanceToNextEdge(); // Falling
+        ReportProgress( mChipSelect->GetSampleNumber() );
+        mClock->AdvanceToAbsPosition(mChipSelect->GetSampleNumber());
     }
 }
 
@@ -212,70 +154,7 @@ U32 SimpleParallelAnalyzer::GetMinimumSampleRateHz()
 
 const char* SimpleParallelAnalyzer::GetAnalyzerName() const
 {
-    return "Simple Parallel";
-}
-
-
-void SimpleParallelAnalyzer::DecodeBothEdges()
-{
-    // helper to allow us to successfully report the last edge, even if there are no more edges in the capture.
-    // Normally, in order to report a specific edge, the following edge must be found first.
-    // If that following edge does not exist, and never will exist, instead we advance a intermediate amount, and return false.
-    // If there is another edge, we advance to it and return true.
-    // force_advance optionally ensures we advance to the next edge. If there are no more edges in the data, this will never return.
-    auto advance_to_next_edge_or_fail = [&]( bool force_advance ) -> bool {
-        if( mClock->DoMoreTransitionsExistInCurrentData() || force_advance )
-        {
-            mClock->AdvanceToNextEdge();
-            return true;
-        }
-        int64_t estimated_frame_size = mLastFrameWidth > 0 ? std::max<int64_t>( static_cast<int64_t>( mLastFrameWidth * 0.1 ), 2 ) : 10;
-        if( mClock->WouldAdvancingCauseTransition( estimated_frame_size ) )
-        {
-            // this condition will only be true if we're very lucky, and we're processing data while recording in real time.
-            mClock->AdvanceToNextEdge();
-            return true;
-        }
-        mClock->Advance( estimated_frame_size );
-        return false;
-    };
-
-    // Frames start at the active edge, and extend to the following edge -1. (or they extend to an estimated width, if no more data is
-    // found.)
-    // we must advance past the active edge before committing the result from that edge.
-
-    // has_pending_frame indicates that we have a word to store after the previous cycle.
-    bool has_pending_frame = false;
-    uint16_t previous_value = 0;
-    uint64_t previous_sample = 0;
-
-    for( ;; )
-    {
-        // advance to the next active edge.
-        auto found_next_edge = advance_to_next_edge_or_fail( !has_pending_frame );
-        auto location = mClock->GetSampleNumber();
-        uint64_t progress_update = 0;
-        if( has_pending_frame )
-        {
-            // store the previous frame.
-            progress_update = AddFrame( previous_value, previous_sample, location - 1 );
-            has_pending_frame = false;
-        }
-        if( found_next_edge )
-        {
-            has_pending_frame = true;
-            previous_sample = location;
-            previous_value = GetWordAtLocation( location );
-
-            mResults->AddMarker( location, mClock->GetBitState() == BIT_LOW ? AnalyzerResults::DownArrow : AnalyzerResults::UpArrow,
-                                 mSettings->mClockChannel );
-        }
-
-        if( progress_update > 0 )
-        {
-            ReportProgress( progress_update );
-        }
-    }
+    return "Simple Parallel w/CS";
 }
 
 uint16_t SimpleParallelAnalyzer::GetWordAtLocation( uint64_t sample_number )
@@ -297,27 +176,9 @@ uint16_t SimpleParallelAnalyzer::GetWordAtLocation( uint64_t sample_number )
     return result;
 }
 
-uint64_t SimpleParallelAnalyzer::AddFrame( uint16_t value, uint64_t starting_sample, uint64_t ending_sample )
-{
-    assert( starting_sample <= ending_sample );
-    FrameV2 frame_v2;
-    frame_v2.AddInteger( "data", value );
-
-    Frame frame;
-    frame.mData1 = value;
-    frame.mFlags = 0;
-    frame.mStartingSampleInclusive = starting_sample;
-    frame.mEndingSampleInclusive = ending_sample;
-    mResults->AddFrame( frame );
-    mResults->AddFrameV2( frame_v2, "data", frame.mStartingSampleInclusive, frame.mEndingSampleInclusive );
-    mResults->CommitResults();
-    mLastFrameWidth = std::max<uint64_t>( ending_sample - starting_sample, 1 );
-    return ending_sample;
-}
-
 const char* GetAnalyzerName()
 {
-    return "Simple Parallel";
+    return "Simple Parallel w/CS";
 }
 
 Analyzer* CreateAnalyzer()

--- a/src/SimpleParallelAnalyzer.h
+++ b/src/SimpleParallelAnalyzer.h
@@ -37,6 +37,7 @@ class SimpleParallelAnalyzer : public Analyzer2
     std::vector<U16> mDataMasks;
     std::vector<Channel> mDataChannels;
     AnalyzerChannelData* mClock;
+    AnalyzerChannelData* mChipSelect;
 
     SimpleParallelSimulationDataGenerator mSimulationDataGenerator;
     bool mSimulationInitilized;

--- a/src/SimpleParallelAnalyzerSettings.cpp
+++ b/src/SimpleParallelAnalyzerSettings.cpp
@@ -6,7 +6,7 @@
 #pragma warning( disable : 4996 ) // warning C4996: 'sprintf': This function or variable may be unsafe
 
 SimpleParallelAnalyzerSettings::SimpleParallelAnalyzerSettings()
-    : mClockChannel( UNDEFINED_CHANNEL ), mClockEdge( ParallelAnalyzerClockEdge::PosEdge )
+    : mClockChannel( UNDEFINED_CHANNEL ), mChipSelectChannel( UNDEFINED_CHANNEL ), mClockEdge( ParallelAnalyzerClockEdge::PosEdge )
 {
     U32 count = 16;
     for( U32 i = 0; i < count; i++ )
@@ -29,11 +29,16 @@ SimpleParallelAnalyzerSettings::SimpleParallelAnalyzerSettings()
     mClockChannelInterface->SetTitleAndTooltip( "Clock", "Clock" );
     mClockChannelInterface->SetChannel( mClockChannel );
 
+
+    mChipSelectChannelInterface.reset( new AnalyzerSettingInterfaceChannel() );
+    mChipSelectChannelInterface->SetTitleAndTooltip( "Chip Select", "Chip Select" );
+    mChipSelectChannelInterface->SetChannel( mChipSelectChannel );
+
     mClockEdgeInterface.reset( new AnalyzerSettingInterfaceNumberList() );
     mClockEdgeInterface->SetTitleAndTooltip( "Clock State", "Define whether the data is valid on Clock rising or falling edge" );
     mClockEdgeInterface->AddNumber( static_cast<double>( ParallelAnalyzerClockEdge::PosEdge ), "Rising edge", "" );
     mClockEdgeInterface->AddNumber( static_cast<double>( ParallelAnalyzerClockEdge::NegEdge ), "Falling edge", "" );
-    mClockEdgeInterface->AddNumber( static_cast<double>( ParallelAnalyzerClockEdge::DualEdge ), "Dual edge", "" );
+    // mClockEdgeInterface->AddNumber( static_cast<double>( ParallelAnalyzerClockEdge::DualEdge ), "Dual edge", "" );
     mClockEdgeInterface->SetNumber( static_cast<double>( mClockEdge ) );
 
 
@@ -43,6 +48,7 @@ SimpleParallelAnalyzerSettings::SimpleParallelAnalyzerSettings()
     }
 
     AddInterface( mClockChannelInterface.get() );
+    AddInterface( mChipSelectChannelInterface.get() );
     AddInterface( mClockEdgeInterface.get() );
 
     AddExportOption( 0, "Export as text/csv file" );
@@ -58,6 +64,7 @@ SimpleParallelAnalyzerSettings::SimpleParallelAnalyzerSettings()
     }
 
     AddChannel( mClockChannel, "Clock", false );
+    AddChannel( mChipSelectChannel, "Chip Select", false );
 }
 
 SimpleParallelAnalyzerSettings::~SimpleParallelAnalyzerSettings()
@@ -89,6 +96,7 @@ bool SimpleParallelAnalyzerSettings::SetSettingsFromInterfaces()
     }
 
     mClockChannel = mClockChannelInterface->GetChannel();
+    mChipSelectChannel = mChipSelectChannelInterface->GetChannel();
     mClockEdge = static_cast<ParallelAnalyzerClockEdge>( U32( mClockEdgeInterface->GetNumber() ) );
 
     ClearChannels();
@@ -100,6 +108,7 @@ bool SimpleParallelAnalyzerSettings::SetSettingsFromInterfaces()
     }
 
     AddChannel( mClockChannel, "Clock", true );
+    AddChannel( mChipSelectChannel, "Chip Select", mChipSelectChannel != UNDEFINED_CHANNEL );
 
     return true;
 }
@@ -113,6 +122,7 @@ void SimpleParallelAnalyzerSettings::UpdateInterfacesFromSettings()
     }
 
     mClockChannelInterface->SetChannel( mClockChannel );
+    mChipSelectChannelInterface->SetChannel( mChipSelectChannel );
     mClockEdgeInterface->SetNumber( static_cast<double>( mClockEdge ) );
 }
 
@@ -129,6 +139,7 @@ void SimpleParallelAnalyzerSettings::LoadSettings( const char* settings )
     }
 
     text_archive >> mClockChannel;
+    text_archive >> mChipSelectChannel;
     U32 edge;
     text_archive >> edge;
     mClockEdge = static_cast<ParallelAnalyzerClockEdge>( edge );
@@ -158,6 +169,7 @@ const char* SimpleParallelAnalyzerSettings::SaveSettings()
     }
 
     text_archive << mClockChannel;
+    text_archive << mChipSelectChannel;
     U32 edge = static_cast<U32>( mClockEdge );
     text_archive << edge;
 

--- a/src/SimpleParallelAnalyzerSettings.h
+++ b/src/SimpleParallelAnalyzerSettings.h
@@ -26,6 +26,7 @@ class SimpleParallelAnalyzerSettings : public AnalyzerSettings
 
     std::vector<Channel> mDataChannels;
     Channel mClockChannel;
+    Channel mChipSelectChannel;
 
     ParallelAnalyzerClockEdge mClockEdge;
 
@@ -33,6 +34,7 @@ class SimpleParallelAnalyzerSettings : public AnalyzerSettings
     std::vector<AnalyzerSettingInterfaceChannel*> mDataChannelsInterface;
 
     std::unique_ptr<AnalyzerSettingInterfaceChannel> mClockChannelInterface;
+    std::unique_ptr<AnalyzerSettingInterfaceChannel> mChipSelectChannelInterface;
     std::unique_ptr<AnalyzerSettingInterfaceNumberList> mClockEdgeInterface;
 };
 


### PR DESCRIPTION
Opened as a draft to see if you'd want to integrate this functionality into the shipped version. We'd need to do a couple things before it is backwards compatible:

- [ ] Make CS optional.
- [ ] Add dual edge support back.

Clocks outside chip select low will be ignored. Data captured will include an "index" key with the clock count from the assertion of chip select.

Data frames now span between inactive edges. (Saleae's start on the active edge.) This better mirrors diagrams where data changes around inactive edges. Polarity is also detected at CS assertion and a rising CS edge can be the final inactive edge.