### PR TITLE
Fix bug where decoding with dual edge could not handle single-sample-wide pulses

### DIFF
--- a/src/SimpleParallelAnalyzer.cpp
+++ b/src/SimpleParallelAnalyzer.cpp
@@ -258,7 +258,10 @@ void SimpleParallelAnalyzer::DecodeBothEdges()
         if( has_pending_frame )
         {
             // store the previous frame.
-            progress_update = AddFrame( previous_value, previous_sample, location - 1 );
+            // If we're getting a transition on every sample, we should ensure that each frame is at least 1
+            // sample wide, to avoid 0 length frames, which are hidden in the UI.
+            uint64_t ending_sample_inclusive = std::max<uint64_t>( location - 1, previous_sample + 1 );
+            progress_update = AddFrame( previous_value, previous_sample, ending_sample_inclusive );
             has_pending_frame = false;
         }
         if( found_next_edge )

--- a/src/SimpleParallelAnalyzer.cpp
+++ b/src/SimpleParallelAnalyzer.cpp
@@ -258,9 +258,7 @@ void SimpleParallelAnalyzer::DecodeBothEdges()
         if( has_pending_frame )
         {
             // store the previous frame.
-            // If we're getting a transition on every sample, we should ensure that each frame is at least 1
-            // sample wide, to avoid 0 length frames, which are hidden in the UI.
-            uint64_t ending_sample_inclusive = std::max<uint64_t>( location - 1, previous_sample + 1 );
+            uint64_t ending_sample_inclusive = location;
             progress_update = AddFrame( previous_value, previous_sample, ending_sample_inclusive );
             has_pending_frame = false;
         }


### PR DESCRIPTION
Specifically, if the clock data pattern was alternating every sample, the created frames would be 0 samples side (despite our use of the word "inclusive" would would imply that the same starting and ending sample would be 1 sample wide)

Now the ending sample of the previous frame will be the same as the starting sample of the next frame.